### PR TITLE
Installation fix for Apple Silicon

### DIFF
--- a/lib/python.sh
+++ b/lib/python.sh
@@ -212,7 +212,7 @@ if [ -n "$THIS_SOURCE" ] && [[ "${SOURCES_CACHE[(Ie)$THIS_SOURCE]}" -eq 0 ]]; th
                 continue
             fi
 
-            for python in $(find "$dir" -maxdepth 1 -type f -name 'python?.*' 2>/dev/null | sort -Vr); do
+            for python in $(find "$dir" -follow -maxdepth 1 -type f -name 'python?.*' 2>/dev/null | sort -Vr); do
                 [ ! -x "$python" ] || \
                 [[ ! "$python" -regex-match '[0-9]$' ]] && continue
 

--- a/run/core.sh
+++ b/run/core.sh
@@ -987,6 +987,11 @@ else
     elif [[ "$osname" -regex-match 'darwin' ]]; then
         export ASH_OS="MAC"
         export ASH_ARCH="$(uname -m)"
+
+        if [[ -z "$HOMEBREW_PREFIX" ]]; then
+            fail $0 "Empty Homebrew prefix. Have you followed the post-install instructions it provides?"
+        fi
+
         local linked=0
         if [[ "$ASH_ARCH" -regex-match 'arm64' ]] && [[ -d "$HOMEBREW_PREFIX/bin" ]]; then
             fs.link 'ls'    "$HOMEBREW_PREFIX/bin/gls" >/dev/null && \

--- a/run/path.sh
+++ b/run/path.sh
@@ -23,6 +23,7 @@ fi
 
 perm_path=(
     $perm_path
+    $ASH/bin
     $HOME/.local/bin
     $HOME/bin
     /usr/local/bin

--- a/run/units/compat.sh
+++ b/run/units/compat.sh
@@ -132,10 +132,11 @@ if [ -n "$THIS_SOURCE" ] && [[ "${SOURCES_CACHE[(Ie)$THIS_SOURCE]}" -eq 0 ]]; th
             fi
 
             local cmd="brew update && brew install"
-            local pkg="bash coreutils findutils git gnu-tar grep gsed openssl pkg-config python@3 zsh"
+            local pkg="bash cmake coreutils findutils git gnu-tar grep gsed openssl pkg-config python@3 zsh"
             REQ_SYS_BINS=(
                 bash
                 brew
+                cmake
                 gcut
                 gfind
                 ggrep

--- a/run/units/compat.sh
+++ b/run/units/compat.sh
@@ -136,14 +136,14 @@ if [ -n "$THIS_SOURCE" ] && [[ "${SOURCES_CACHE[(Ie)$THIS_SOURCE]}" -eq 0 ]]; th
             REQ_SYS_BINS=(
                 bash
                 brew
-                /usr/local/bin/gcut
-                /usr/local/bin/gfind
-                /usr/local/bin/ggrep
-                /usr/local/bin/gls
-                /usr/local/bin/greadlink
-                /usr/local/bin/grealpath
-                /usr/local/bin/gsed
-                /usr/local/bin/gtar
+                gcut
+                gfind
+                ggrep
+                gls
+                greadlink
+                grealpath
+                gsed
+                gtar
             )
 
 


### PR DESCRIPTION
Fresh install of Josh on Apple Silicon device failed with multiple errors:

    - Josh expected to find `GNU coreutils` in `/usr/local/bin`, but brew now
      builds them for ARM, so they are located in `/opt/homebrew/` (default
      Apple silicon prefix [1][2]).

      To address the issue, a new linking mechanism was implemented. It looks
      for the GNU binaries in `$HOMEBREW_PREFIX` and `/usr/local/bin`, linking
      binaries that it finds. This will allow those who want to use x86-64 tools
      (for some reason) to do so.

      Also, required binaries list for macOS now does not use concrete paths to
      the GNU utils

    - Josh symlinks the GNU utils to its own `bin`, but it comes after
      `/usr/local/bin` in the `$PATH`, so BSD utilities have priority, leading
      to multiple failures (mostly `grep`-related).

      Fixed this by adding `$ASH/bin` to the `$PATH` calculations.

    - `starship` build requires `cmake` on Apple Silicon. Obvious fix: add the
      `cmake` dependency binary

[1] https://docs.brew.sh/Installation
[2] https://github.com/Homebrew/brew/issues/9177